### PR TITLE
Add resource links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,12 @@ Dosovitskiy, A., Beyer, L., Kolesnikov, A., Weissenborn, D., Zhai, X., Unterthin
 ```
 
 - Implementation by [mrdbourke](https://github.com/mrdbourke) is referred.
+
+## Resources
+
+- [PyTorch Documentation](https://pytorch.org/docs/stable/index.html)
+- [Torchvision Documentation](https://pytorch.org/vision/stable/index.html)
+- [TQDM Documentation](https://tqdm.github.io/)
+- [NumPy Documentation](https://numpy.org/doc/)
+- [Pandas Documentation](https://pandas.pydata.org/docs/)
+- [Matplotlib Documentation](https://matplotlib.org/stable/contents.html)


### PR DESCRIPTION
Add a new "## Resources" section to the `README.md` file.

* Include resource links for:
  - PyTorch Documentation
  - Torchvision Documentation
  - TQDM Documentation
  - NumPy Documentation
  - Pandas Documentation
  - Matplotlib Documentation

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mach-12/vit/pull/3?shareId=a141c134-08f0-4356-968c-ac9d7bbb014b).